### PR TITLE
Fix userinfo banlog order and count

### DIFF
--- a/src/pxls/Pages/Profile.php
+++ b/src/pxls/Pages/Profile.php
@@ -78,7 +78,7 @@ final class Profile
             $userinfo["banlog"] = [
                 "legacy" => $_legacy,
                 "current" => $_current,
-                "count" => $sizes['legacy'] == $sizes['current'] ? $sizes['legacy'] : $sizes['legacy'] - $sizes['current']
+                "count" => $sizes['legacy'] == $sizes['current'] ? $sizes['legacy'] : abs($sizes['legacy'] - $sizes['current'])
             ];
             $userinfo["chatbanlog"] = $user->getChatbanlogFromDB($userinfo['id']);
             $userinfo["ip_log"] = $user->getIPLogForUser($userinfo['id']);

--- a/src/pxls/User.php
+++ b/src/pxls/User.php
@@ -116,7 +116,7 @@ class User {
         $toRet = [];
         $user = $this->getUserById($uid);
         if ($user) {
-            $getBansQuery = $this->db->prepare('SELECT b.id, b.when as "when_timestamp", to_timestamp(b.when) as "when", b.banner as "banner_id", COALESCE(u.username, \'console\') as "banner", b.banned as "banned_id", u1.username as "banned", b.ban_expiry as "ban_expiry_timestamp", (CASE WHEN b.ban_expiry != NULL THEN b.ban_expiry ELSE 0 END) as "ban_expiry_date", (CASE WHEN b.ban_expiry - b.when > 0 THEN b.ban_expiry - b.when ELSE -1 END) as "length", b.action, b.ban_reason FROM banlogs b LEFT OUTER JOIN users u ON u.id = b.banner INNER JOIN users u1 ON u1.id = b.banned WHERE b.banned = :id');
+            $getBansQuery = $this->db->prepare('SELECT b.id, b.when as "when_timestamp", to_timestamp(b.when) as "when", b.banner as "banner_id", COALESCE(u.username, \'console\') as "banner", b.banned as "banned_id", u1.username as "banned", b.ban_expiry as "ban_expiry_timestamp", (CASE WHEN b.ban_expiry != NULL THEN b.ban_expiry ELSE 0 END) as "ban_expiry_date", (CASE WHEN b.ban_expiry - b.when > 0 THEN b.ban_expiry - b.when ELSE -1 END) as "length", b.action, b.ban_reason FROM banlogs b LEFT OUTER JOIN users u ON u.id = b.banner INNER JOIN users u1 ON u1.id = b.banned WHERE b.banned = :id ORDER BY b.when ASC');
             $getBansQuery->bindParam(':id', $uid);
             $getBansQuery->execute();
             if ($getBansQuery->rowCount() > 0) {
@@ -149,7 +149,7 @@ class User {
         $toRet = [];
         $user = $this->getUserById($uid);
         if ($user) {
-            $getBansQuery = $this->db->prepare('SELECT b.id, b.when as "when_timestamp", to_timestamp(b.when) as "when", b.initiator as "banner_id", COALESCE(u.username, \'console\') as "banner", b.target as "banned_id", u1.username as "banned", b.expiry as "ban_expiry_timestamp", (CASE WHEN b.expiry != NULL THEN b.expiry ELSE 0 END) as "ban_expiry_date", (CASE WHEN b.expiry - b.when > 0 THEN b.expiry - b.when ELSE -1 END) as "length", b.type, b.purged, b.reason as ban_reason FROM chatbans b LEFT OUTER JOIN users u ON u.id = b.initiator INNER JOIN users u1 ON u1.id = b.target WHERE b.target = :id');
+            $getBansQuery = $this->db->prepare('SELECT b.id, b.when as "when_timestamp", to_timestamp(b.when) as "when", b.initiator as "banner_id", COALESCE(u.username, \'console\') as "banner", b.target as "banned_id", u1.username as "banned", b.expiry as "ban_expiry_timestamp", (CASE WHEN b.expiry != NULL THEN b.expiry ELSE 0 END) as "ban_expiry_date", (CASE WHEN b.expiry - b.when > 0 THEN b.expiry - b.when ELSE -1 END) as "length", b.type, b.purged, b.reason as ban_reason FROM chatbans b LEFT OUTER JOIN users u ON u.id = b.initiator INNER JOIN users u1 ON u1.id = b.target WHERE b.target = :id ORDER BY b.when ASC');
             $getBansQuery->bindParam(':id', $uid);
             $getBansQuery->execute();
             if ($getBansQuery->rowCount() > 0) {


### PR DESCRIPTION
- Make sure banlogs and chatbanlogs are ordered by date.
-  Fix banlog count badge not showing when the number of `legacy` bans is higher than the number of `current` bans