### PR TITLE
Add parsing for more logs

### DIFF
--- a/src/pxls/LogParser.php
+++ b/src/pxls/LogParser.php
@@ -21,9 +21,10 @@ class LogParser {
         $regex['chatban'] = '/\(chatban\) TEMP: {Target: (\S*)} {Initiator: (\S*)} {Length: (\S*)} {Purge: (true|false)} {PurgeAmount: (\d+)} {Reason: (.+)}/i';
         $regex['chatpurge'] = '/<(\S*), (\d*)> purged (\d*) messages from <(\S*), (\d*)>/i';
         $regex['chatdelete'] = '/<(\S*), (\d*)> purged message with id (\d*) from <(\S*), (\d*)>/i';
-        $regex['setrole'] = '/Set (\S*)\'s role to (\S*)/i'; // Kept for legacy reasons
+        $regex['setroles'] = '/Set (\S*)\'s roles? to (\S*)/i';
         $regex['addroles'] = '/Added roles "(.+)" to (\S*)/i';
         $regex['removeroles'] = '/Removed roles "(.+)" from (\S*)/i';
+        $regex['removeallroles'] = '/Removed (\S*)\'s roles/i';
         $regex['flagrename'] = '/((?:un)?flagged) (\S*) \((\d+)\) for name change/i';
         $regex['rename'] = '/User (\S*) \((\d+)\) has just changed their name to (\S*)/i';
         $regex['forcedrename'] = '/Changed (\S*)\'s name to (\S*) \(uid: (\d*)\)/i';
@@ -90,8 +91,7 @@ class LogParser {
                 case 'chatdelete':
                     return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[4][0], 'extra' => ['cmid' => $matches[3][0], 'uid' => $matches[5][0]]];
                     break;
-                case 'setrole':
-                    // Kept for legacy reasons
+                case 'setroles':
                     return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[1][0], 'extra' => $matches[2][0]];
                     break;
                 case 'addroles':
@@ -99,6 +99,9 @@ class LogParser {
                     break;
                 case 'removeroles':
                     return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => $matches[1][0]];
+                    break;
+                case 'removeallroles':
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[1][0]];
                     break;
                 case 'flagrename':
                     return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => ['action' => strtolower($matches[1][0]), 'uid' => $matches[3][0]]];
@@ -135,23 +138,24 @@ class LogParser {
     public function humanLogMessage($messageArray,$user_name,$raw_message) {
         $m = $messageArray; $messageTpl = [];
         // Scope: ModAction
-        $messageTpl["modaction"]["selfshadow"]   = '<a href="/userinfo/%user_name%" target="_blank">%user_name%</a> was shadowbanned automatically. (%extra%)';
-        $messageTpl["modaction"]["selfban"]      = '<a href="/userinfo/%user_name%" target="_blank">%user_name%</a> was banned automatically. (Scripting)';
-        $messageTpl["modaction"]["permaban"]     = '<a href="/userinfo/%target%" target="_blank">%target%</a> was canvas banned permanently.';
-        $messageTpl["modaction"]["shadowban"]    = '<a href="/userinfo/%target%" target="_blank">%target%</a> was shadowbanned.';
-        $messageTpl["modaction"]["ban"]          = '<a href="/userinfo/%target%" target="_blank">%target%</a> was canvas time-banned.';
-        $messageTpl["modaction"]["unban"]        = '<a href="/userinfo/%target%" target="_blank">%target%</a> was canvas unbanned.';
-        $messageTpl["modaction"]["chatpermaban"] = '<a href="/userinfo/%target%" target="_blank">%target%</a> was chat banned permanently%extra%.';
-        $messageTpl["modaction"]["chatban"]      = '<a href="/userinfo/%target%" target="_blank">%target%</a> was chat time-banned%extra%.';
-        $messageTpl["modaction"]["chatunban"]    = '<a href="/userinfo/%target%" target="_blank">%target%</a> was chat unbanned.';
-        $messageTpl["modaction"]["chatpurge"]    = '%extra.amount% messages from <a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) were purged from chat.';
-        $messageTpl["modaction"]["chatdelete"]   = 'Message <a href="/chatContext?cmid=%extra.cmid%" target="_blank">ID %extra.cmid%</a> from <a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) was deleted from chat.';
-        $messageTpl["modaction"]["setrole"]      = '<a href="/userinfo/%target%" target="_blank">%target%</a> was pro/demoted to %extra%.';
-        $messageTpl["modaction"]["addroles"]     = '<a href="/userinfo/%target%" target="_blank">%target%</a> was given the role(s) %extra%.';
-        $messageTpl["modaction"]["removeroles"]  = '<a href="/userinfo/%target%" target="_blank">%target%</a> was revoked of the role(s) %extra%.';
-        $messageTpl["modaction"]["flagrename"]   = '<a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) was %extra.action% for rename.';
-        $messageTpl["modaction"]["rename"]       = '<a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) changed their name from %extra.old_username% to %target%.';
-        $messageTpl["modaction"]["forcedrename"] = '<a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%)\'s name was forcefully changed from %extra.old_username% to %target%.';
+        $messageTpl["modaction"]["selfshadow"]     = '<a href="/userinfo/%user_name%" target="_blank">%user_name%</a> was shadowbanned automatically. (%extra%)';
+        $messageTpl["modaction"]["selfban"]        = '<a href="/userinfo/%user_name%" target="_blank">%user_name%</a> was banned automatically. (Scripting)';
+        $messageTpl["modaction"]["permaban"]       = '<a href="/userinfo/%target%" target="_blank">%target%</a> was canvas banned permanently.';
+        $messageTpl["modaction"]["shadowban"]      = '<a href="/userinfo/%target%" target="_blank">%target%</a> was shadowbanned.';
+        $messageTpl["modaction"]["ban"]            = '<a href="/userinfo/%target%" target="_blank">%target%</a> was canvas time-banned.';
+        $messageTpl["modaction"]["unban"]          = '<a href="/userinfo/%target%" target="_blank">%target%</a> was canvas unbanned.';
+        $messageTpl["modaction"]["chatpermaban"]   = '<a href="/userinfo/%target%" target="_blank">%target%</a> was chat banned permanently%extra%.';
+        $messageTpl["modaction"]["chatban"]        = '<a href="/userinfo/%target%" target="_blank">%target%</a> was chat time-banned%extra%.';
+        $messageTpl["modaction"]["chatunban"]      = '<a href="/userinfo/%target%" target="_blank">%target%</a> was chat unbanned.';
+        $messageTpl["modaction"]["chatpurge"]      = '%extra.amount% messages from <a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) were purged from chat.';
+        $messageTpl["modaction"]["chatdelete"]     = 'Message <a href="/chatContext?cmid=%extra.cmid%" target="_blank">ID %extra.cmid%</a> from <a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) was deleted from chat.';
+        $messageTpl["modaction"]["setroles"]       = '<a href="/userinfo/%target%" target="_blank">%target%</a>\'s role(s) were set to %extra%.';
+        $messageTpl["modaction"]["addroles"]       = '<a href="/userinfo/%target%" target="_blank">%target%</a> was given the role(s) %extra%.';
+        $messageTpl["modaction"]["removeroles"]    = '<a href="/userinfo/%target%" target="_blank">%target%</a> was revoked of the role(s) %extra%.';
+        $messageTpl["modaction"]["removeallroles"] = '<a href="/userinfo/%target%" target="_blank">%target%</a> had all of their roles removed.';
+        $messageTpl["modaction"]["flagrename"]     = '<a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) was %extra.action% for rename.';
+        $messageTpl["modaction"]["rename"]         = '<a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) changed their name from %extra.old_username% to %target%.';
+        $messageTpl["modaction"]["forcedrename"]   = '<a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%)\'s name was forcefully changed from %extra.old_username% to %target%.';
         // Scope: Report
         $messageTpl["report"]["canvasclaim"]   = 'Canvas Report <a href="#" data-toggle="modal" data-reportid="%target%" data-target="#report_info">ID %target%</a> has been claimed';
         $messageTpl["report"]["canvasunclaim"] = 'Canvas Report <a href="#" data-toggle="modal" data-reportid="%target%" data-target="#report_info">ID %target%</a> has been unclaimed';

--- a/src/pxls/LogParser.php
+++ b/src/pxls/LogParser.php
@@ -72,7 +72,7 @@ class LogParser {
                     return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[3][0], 'extra' => [ 'old_username' => $matches[1][0], 'uid' => $matches[2][0] ]];
                     break;
                 case 'forcedrename':
-                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => [ 'old_username' => $matches[1][0], 'uid' => $matches[1][0] ]];
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => [ 'old_username' => $matches[1][0], 'uid' => $matches[3][0] ]];
                     break;
                 case 'claim':
                     return ['scope' => 'report', 'action' => $action, 'target' => $matches[2][0], 'extra' => ''];

--- a/src/pxls/LogParser.php
+++ b/src/pxls/LogParser.php
@@ -12,19 +12,27 @@ class LogParser {
         $regex = []; $action = null;
         $regex['selfshadow'] = '/self-shadowban via (.+)/i';
         $regex['selfban'] = '/self-ban via script/i';
-        $regex['permaban'] = '/(permaban) (\S*)/i';
-        $regex['shadowban'] = '/(shadowban) (\S*)/i';
-        $regex['unban'] = '/(unban) (\S*)/i';
-        $regex['ban'] = '/(ban) (\S*)/i';
+        $regex['permaban'] = '/^(permaban) (\S*)/i';
+        $regex['shadowban'] = '/^(shadowban) (\S*)/i';
+        $regex['unban'] = '/^(unban) (\S*)/i';
+        $regex['ban'] = '/^(ban) (\S*)/i';
+        $regex['chatpermaban'] = '/\(chatban\) PERMA: {Target: (\S*)} {Initiator: (\S*)} {Length: (\S*)} {Purge: (true|false)} {PurgeAmount: (\d+)} {Reason: (.+)}/i';
+        $regex['chatunban'] = '/\(chatban\) UNBAN: {Target: (\S*)} {Initiator: (\S*)} {Length: (\S*)} {Purge: (true|false)} {PurgeAmount: (\d+)} {Reason: (.+)}/i';
+        $regex['chatban'] = '/\(chatban\) TEMP: {Target: (\S*)} {Initiator: (\S*)} {Length: (\S*)} {Purge: (true|false)} {PurgeAmount: (\d+)} {Reason: (.+)}/i';
+        $regex['chatpurge'] = '/<(\S*), (\d*)> purged (\d*) messages from <(\S*), (\d*)>/i';
+        $regex['chatdelete'] = '/<(\S*), (\d*)> purged message with id (\d*) from <(\S*), (\d*)>/i';
         $regex['setrole'] = '/Set (\S*)\'s role to (\S*)/i'; // Kept for legacy reasons
         $regex['addroles'] = '/Added roles "(.+)" to (\S*)/i';
         $regex['removeroles'] = '/Removed roles "(.+)" from (\S*)/i';
-        $regex['flagrename'] = '/Flagged (\S*) \((\d+)\) for name change/i';
+        $regex['flagrename'] = '/((?:un)?flagged) (\S*) \((\d+)\) for name change/i';
         $regex['rename'] = '/User (\S*) \((\d+)\) has just changed their name to (\S*)/i';
         $regex['forcedrename'] = '/Changed (\S*)\'s name to (\S*) \(uid: (\d*)\)/i';
-        $regex['unclaim'] = '/(unclaimed report) (\S*)/i';
-        $regex['claim'] = '/(claimed report) (\S*)/i';
-        $regex['resolve'] = '/(resolved report) (\S*)/i';
+        $regex['canvasunclaim'] = '/(unclaimed report) (\S*)/i';
+        $regex['canvasclaim'] = '/(claimed report) (\S*)/i';
+        $regex['canvasresolve'] = '/(resolved report) (\S*)/i';
+        $regex['chatunclaim'] = '/(unclaimed chat report) (\S*)/i';
+        $regex['chatclaim'] = '/(claimed chat report) (\S*)/i';
+        $regex['chatresolve'] = '/(resolved chat report) (\S*)/i';
         $regex['publicapi'] = '/(public api invoked by) (\S*)/i';
         $regex['ratelimit'] = '/(ratelimited) (\S*)/i';
 
@@ -38,22 +46,49 @@ class LogParser {
         if(isset($matches)) {
             switch($action) {
                 case 'selfban':
-                    return ['scope' => 'modaction', 'action' => $action, 'target' => '', 'extra' => ''];
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => ''];
                     break;
                 case 'selfshadow':
                     return ['scope' => 'modaction', 'action' => $action, 'target' => '', 'extra' => $matches[1][0]];
                     break;
                 case 'permaban':
-                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => ''];
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0]];
                     break;
                 case 'shadowban':
-                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => ''];
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0]];
                     break;
                 case 'unban':
-                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => ''];
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0]];
                     break;
                 case 'ban':
-                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => ''];
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0]];
+                    break;
+                case 'chatpermaban':
+                    $purgeCount = intval($matches[5][0]);
+                    if ($purgeCount >= 2147483647) {
+                        $purgeCount = "all";
+                    }
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[1][0], 'extra' => $matches[4][0] === 'true' ? " and got $purgeCount messages purged" : ''];
+                    break;
+                case 'chatunban':
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[1][0]];
+                    break;
+                case 'chatban':
+                    $purgeCount = intval($matches[5][0]);
+                    if ($purgeCount >= 2147483647) {
+                        $purgeCount = "all";
+                    }
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[1][0], 'extra' => $matches[4][0] === 'true' ? " and got $purgeCount messages purged" : ''];
+                    break;
+                case 'chatpurge':
+                    $amount = intval($matches[3][0]);
+                    if ($amount >= 2147483647) {
+                        $amount = 'All';
+                    }
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[4][0], 'extra' => ['amount' => $amount, 'uid' => $matches[5][0]]];
+                    break;
+                case 'chatdelete':
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[4][0], 'extra' => ['cmid' => $matches[3][0], 'uid' => $matches[5][0]]];
                     break;
                 case 'setrole':
                     // Kept for legacy reasons
@@ -66,28 +101,31 @@ class LogParser {
                     return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => $matches[1][0]];
                     break;
                 case 'flagrename':
-                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[1][0], 'extra' => $matches[2][0]];
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => ['action' => strtolower($matches[1][0]), 'uid' => $matches[3][0]]];
                     break;
                 case 'rename':
-                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[3][0], 'extra' => [ 'old_username' => $matches[1][0], 'uid' => $matches[2][0] ]];
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[3][0], 'extra' => ['old_username' => $matches[1][0], 'uid' => $matches[2][0]]];
                     break;
                 case 'forcedrename':
-                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => [ 'old_username' => $matches[1][0], 'uid' => $matches[3][0] ]];
+                    return ['scope' => 'modaction', 'action' => $action, 'target' => $matches[2][0], 'extra' => ['old_username' => $matches[1][0], 'uid' => $matches[3][0]]];
                     break;
-                case 'claim':
-                    return ['scope' => 'report', 'action' => $action, 'target' => $matches[2][0], 'extra' => ''];
+                case 'canvasclaim':
+                case 'chatclaim':
+                    return ['scope' => 'report', 'action' => $action, 'target' => $matches[2][0]];
                     break;
-                case 'unclaim':
-                    return ['scope' => 'report', 'action' => $action, 'target' => $matches[2][0], 'extra' => ''];
+                case 'canvasunclaim':
+                case 'chatunclaim':
+                    return ['scope' => 'report', 'action' => $action, 'target' => $matches[2][0]];
                     break;
-                case 'resolve':
-                    return ['scope' => 'report', 'action' => $action, 'target' => $matches[2][0], 'extra' => ''];
+                case 'canvasresolve':
+                case 'chatresolve':
+                    return ['scope' => 'report', 'action' => $action, 'target' => $matches[2][0]];
                     break;
                 case 'publicapi':
-                    return ['scope' => 'api', 'action' => $action, 'target' => $matches[2][0], 'extra' => ''];
+                    return ['scope' => 'api', 'action' => $action, 'target' => $matches[2][0]];
                     break;
                 case 'ratelimit':
-                    return ['scope' => 'api', 'action' => $action, 'target' => $matches[2][0], 'extra' => ''];
+                    return ['scope' => 'api', 'action' => $action, 'target' => $matches[2][0]];
                     break;
             }
         }
@@ -99,20 +137,28 @@ class LogParser {
         // Scope: ModAction
         $messageTpl["modaction"]["selfshadow"]   = '<a href="/userinfo/%user_name%" target="_blank">%user_name%</a> was shadowbanned automatically. (%extra%)';
         $messageTpl["modaction"]["selfban"]      = '<a href="/userinfo/%user_name%" target="_blank">%user_name%</a> was banned automatically. (Scripting)';
-        $messageTpl["modaction"]["permaban"]     = '<a href="/userinfo/%target%" target="_blank">%target%</a> was banned permanently.';
+        $messageTpl["modaction"]["permaban"]     = '<a href="/userinfo/%target%" target="_blank">%target%</a> was canvas banned permanently.';
         $messageTpl["modaction"]["shadowban"]    = '<a href="/userinfo/%target%" target="_blank">%target%</a> was shadowbanned.';
-        $messageTpl["modaction"]["ban"]          = '<a href="/userinfo/%target%" target="_blank">%target%</a> was time-banned.';
-        $messageTpl["modaction"]["unban"]        = '<a href="/userinfo/%target%" target="_blank">%target%</a> was unbanned.';
+        $messageTpl["modaction"]["ban"]          = '<a href="/userinfo/%target%" target="_blank">%target%</a> was canvas time-banned.';
+        $messageTpl["modaction"]["unban"]        = '<a href="/userinfo/%target%" target="_blank">%target%</a> was canvas unbanned.';
+        $messageTpl["modaction"]["chatpermaban"] = '<a href="/userinfo/%target%" target="_blank">%target%</a> was chat banned permanently%extra%.';
+        $messageTpl["modaction"]["chatban"]      = '<a href="/userinfo/%target%" target="_blank">%target%</a> was chat time-banned%extra%.';
+        $messageTpl["modaction"]["chatunban"]    = '<a href="/userinfo/%target%" target="_blank">%target%</a> was chat unbanned.';
+        $messageTpl["modaction"]["chatpurge"]    = '%extra.amount% messages from <a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) were purged from chat.';
+        $messageTpl["modaction"]["chatdelete"]   = 'Message <a href="/chatContext?cmid=%extra.cmid%" target="_blank">ID %extra.cmid%</a> from <a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) was deleted from chat.';
         $messageTpl["modaction"]["setrole"]      = '<a href="/userinfo/%target%" target="_blank">%target%</a> was pro/demoted to %extra%.';
         $messageTpl["modaction"]["addroles"]     = '<a href="/userinfo/%target%" target="_blank">%target%</a> was given the role(s) %extra%.';
         $messageTpl["modaction"]["removeroles"]  = '<a href="/userinfo/%target%" target="_blank">%target%</a> was revoked of the role(s) %extra%.';
-        $messageTpl["modaction"]["flagrename"]   = '<a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra%) was flagged for rename.';
+        $messageTpl["modaction"]["flagrename"]   = '<a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) was %extra.action% for rename.';
         $messageTpl["modaction"]["rename"]       = '<a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%) changed their name from %extra.old_username% to %target%.';
         $messageTpl["modaction"]["forcedrename"] = '<a href="/userinfo/%target%" target="_blank">%target%</a> (UID %extra.uid%)\'s name was forcefully changed from %extra.old_username% to %target%.';
         // Scope: Report
-        $messageTpl["report"]["claim"]       = 'Report <a href="#" data-toggle="modal" data-reportid="%target%" data-target="#report_info">ID %target%</a> has been claimed';
-        $messageTpl["report"]["unclaim"]     = 'Report <a href="#" data-toggle="modal" data-reportid="%target%" data-target="#report_info">ID %target%</a> has been unclaimed';
-        $messageTpl["report"]["resolve"]     = 'Report <a href="#" data-toggle="modal" data-reportid="%target%" data-target="#report_info">ID %target%</a> has been resolved';
+        $messageTpl["report"]["canvasclaim"]   = 'Canvas Report <a href="#" data-toggle="modal" data-reportid="%target%" data-target="#report_info">ID %target%</a> has been claimed';
+        $messageTpl["report"]["canvasunclaim"] = 'Canvas Report <a href="#" data-toggle="modal" data-reportid="%target%" data-target="#report_info">ID %target%</a> has been unclaimed';
+        $messageTpl["report"]["canvasresolve"] = 'Canvas Report <a href="#" data-toggle="modal" data-reportid="%target%" data-target="#report_info">ID %target%</a> has been resolved';
+        $messageTpl["report"]["chatclaim"]     = 'Chat Report <a href="#" data-toggle="modal" data-reportid="%target%" data-target="#chat_report_modal">ID %target%</a> has been claimed';
+        $messageTpl["report"]["chatunclaim"]   = 'Chat Report <a href="#" data-toggle="modal" data-reportid="%target%" data-target="#chat_report_modal">ID %target%</a> has been unclaimed';
+        $messageTpl["report"]["chatresolve"]   = 'Chat Report <a href="#" data-toggle="modal" data-reportid="%target%" data-target="#chat_report_modal">ID %target%</a> has been resolved';
         // Scope: API
         $messageTpl["api"]["publicapi"]     = '[ACCESS] <a target="_ipinfo" href="http://netip.de/search?query=%target%">%target%</a> accessed the public api (<a target="_ipinfo" href="https://apps.db.ripe.net/search/query.html?searchtext=%target%">RIPE</a>)';
         $messageTpl["api"]["ratelimit"]     = '[RATELIMIT] <a target="_ipinfo" href="http://netip.de/search?query=%target%">%target%</a> exceeded 15 requests per 15 minutes.  (<a target="_ipinfo" href="https://apps.db.ripe.net/search/query.html?searchtext=%target%">RIPE</a>)';

--- a/src/pxls/Pages/Report.php
+++ b/src/pxls/Pages/Report.php
@@ -41,7 +41,7 @@ final class Report
                 if(isset($params[1])) {
                     $reportId = intval($params[1]);
                     $this->reportInterface->claim($reportId, 1);
-                    $this->logger->info("claimed report $reportId",array(':userid'=>$_SESSION['user_id']));
+                    $this->logger->info("claimed report $reportId",array('userid'=>$_SESSION['user_id']));
                     return $response->withStatus(200)->withJson(["status"=>"success"]);
                 }
                 break;
@@ -49,7 +49,7 @@ final class Report
                 if(isset($params[1])) {
                     $reportId = intval($params[1]);
                     $this->reportInterface->claim($reportId, 0);
-                    $this->logger->info("unclaimed report $reportId",array(':userid'=>$_SESSION['user_id']));
+                    $this->logger->info("unclaimed report $reportId",array('userid'=>$_SESSION['user_id']));
                     return $response->withStatus(200)->withJson(["status"=>"success"]);
                 }
                 break;
@@ -57,10 +57,10 @@ final class Report
                 if(isset($params[1])) {
                     $reportId = intval($params[1]);
                     if ($this->reportInterface->resolve($reportId)) {
-                        $this->logger->info("resolved report $reportId",array(':userid'=>$_SESSION['user_id']));
+                        $this->logger->info("resolved report $reportId",array('userid'=>$_SESSION['user_id']));
                         return $response->withStatus(200)->withJson(["status"=>"success"]);
                     } else {
-                        $this->logger->info("failed to resolve a report because they did not own it ($reportId)",array(':userid'=>$_SESSION['user_id']));
+                        $this->logger->info("failed to resolve a report because they did not own it ($reportId)",array('userid'=>$_SESSION['user_id']));
                         return $response->withStatus(400)->withJson(["status"=>"failed","reason"=>"claimed by someone else"]);
                     }
                 }
@@ -75,7 +75,7 @@ final class Report
                 if(isset($params[1])) {
                     $reportId = intval($params[1]);
                     $this->chatReportInterface->setClaimed($reportId, true);
-                    $this->logger->info("claimed chat report $reportId",array(':userid'=>$_SESSION['user_id']));
+                    $this->logger->info("claimed chat report $reportId",array('userid'=>$_SESSION['user_id']));
                     return $response->withStatus(200)->withJson(["status"=>"success"]);
                 }
                 break;
@@ -83,7 +83,7 @@ final class Report
                 if(isset($params[1])) {
                     $reportId = intval($params[1]);
                     $this->chatReportInterface->setClaimed($reportId, false);
-                    $this->logger->info("unclaimed chat report $reportId",array(':userid'=>$_SESSION['user_id']));
+                    $this->logger->info("unclaimed chat report $reportId",array('userid'=>$_SESSION['user_id']));
                     return $response->withStatus(200)->withJson(["status"=>"success"]);
                 }
                 break;
@@ -91,10 +91,10 @@ final class Report
                 if(isset($params[1])) {
                     $reportId = intval($params[1]);
                     if ($this->chatReportInterface->setResolved($reportId, true)) {
-                        $this->logger->info("resolved chat report $reportId",array(':userid'=>$_SESSION['user_id']));
+                        $this->logger->info("resolved chat report $reportId",array('userid'=>$_SESSION['user_id']));
                         return $response->withStatus(200)->withJson(["status"=>"success"]);
                     } else {
-                        $this->logger->info("failed to resolve a chat report because they did not own it ($reportId)",array(':userid'=>$_SESSION['user_id']));
+                        $this->logger->info("failed to resolve a chat report because they did not own it ($reportId)",array('userid'=>$_SESSION['user_id']));
                         return $response->withStatus(400)->withJson(["status"=>"failed","reason"=>"claimed by someone else"]);
                     }
                 }
@@ -142,19 +142,20 @@ final class Report
 
 
     protected function error(Response $response) {
+        // NOTE(netux): we probably want to remove this...
         $html = <<<HTML
 <pre>
-                       (                                                 
-            _           ) )                                              
-         _,(_)._        ((     I'M A LITTLE TEAPOT SHORT AND STOUT       
-    ___,(_______).        )                                              
+                       (
+            _           ) )
+         _,(_)._        ((     I'M A LITTLE TEAPOT SHORT AND STOUT
+    ___,(_______).        )
   ,'__.   /       \    /\_      THIS IS MY (CENSORED) AND THIS IS MY CUNT
- /,' /  |""|       \  /  /                                               
-| | |   |__|       |,'  /                                                
- \`.|                  /                                                 
-  `. :           :    /                                                  
-    `.            :.,'                                                   
-Stef  `-.________,-'                                                     
+ /,' /  |""|       \  /  /
+| | |   |__|       |,'  /
+ \`.|                  /
+  `. :           :    /
+    `.            :.,'
+Stef  `-.________,-'
 </pre>
 HTML;
         $response->getBody()->write($html);

--- a/templates/ChatContext.html.twig
+++ b/templates/ChatContext.html.twig
@@ -29,8 +29,14 @@
     <script src="{{ base_url() }}/assets/plugins/datatables/extensions/Scroller/js/dataTables.scroller.js"></script>
     <script type="text/javascript">
         (function() {
+            const searchParams = new URLSearchParams(location.search.slice(1));
+
+            const cmidInp = document.getElementById('cmid');
             document.getElementById('btnSubmit').onclick = function() {
-                doPost(document.getElementById('cmid').value);
+                const cmid = cmidInp.value;
+                searchParams.set('cmid', cmid);
+                history.replaceState(null, '', `?${searchParams.toString()}`)
+                doPost(cmid);
             };
             document.getElementById('btnBack').onclick = function() {
                 doPost(this.dataset.cmid);
@@ -69,6 +75,14 @@
                         }
                     }
                 }).fail(console.error);
+            }
+
+            if (searchParams.has('cmid')) {
+                try {
+                    const cmid = parseInt(searchParams.get('cmid'));
+                    cmidInp.value = cmid;
+                    doPost(cmid);
+                } catch (ex) {}
             }
         })();
     </script>


### PR DESCRIPTION
This PR aims to improve readability of the Last Actions section on the Home page.

From something like this
![eww](https://user-images.githubusercontent.com/6181929/97938470-3b117d80-1d60-11eb-8e31-d4e1124c4256.png)

to something like this
![*o*](https://user-images.githubusercontent.com/6181929/97938582-862b9080-1d60-11eb-834b-b1e50e38f66e.png)

This brings log parsing on par with the logs inserted by pxlsspace/Pxls at commit e04e57dae3de811cddd81f19f108303d2d21205b
