### PR TITLE
Add /userinfo/id/{id} and /profile/{params for userinfo} paths

### DIFF
--- a/src/pxls/LogParser.php
+++ b/src/pxls/LogParser.php
@@ -2,6 +2,7 @@
 
 namespace pxls;
 
+// TODO(netux): replace /userinfo/{username} with /userinfo/id/{id} when possible once pxlsspace/PxlsAdmin#17 is merged
 class LogParser {
 
     public function __construct() {

--- a/src/pxls/Pages/PrivateAPI.php
+++ b/src/pxls/Pages/PrivateAPI.php
@@ -87,6 +87,8 @@ final class PrivateAPI
     }
 
     protected function lastSignups() {
+        global $app;
+
         $toRet = [];
         $qSignups = $this->database->query("SELECT id,username,signup_time,login,ban_reason,(is_shadow_banned OR CAST(EXTRACT(epoch FROM ban_expiry) AS INTEGER) = 0 OR (now() < ban_expiry)) AS \"banned\",signup_ip,last_ip,pixel_count FROM users ORDER BY signup_time DESC LIMIT 100");
         $qSignups->execute();
@@ -105,7 +107,7 @@ final class PrivateAPI
             $signup["last_ip"] = $signup["last_ip"];
 
             $username = $signup["username"];
-            $signup["username"] = '<a href="userinfo/'.$username.'" target="_blank">'.$username.'</a>';
+            $signup["username"] = '<a href="'.$app->getContainer()->router->pathFor('profileId', ['id' => $signup['id']]).'" target="_blank">'.$username.'</a>';
 
             $toRet[] = $signup;
         }
@@ -114,6 +116,8 @@ final class PrivateAPI
     }
 
     protected function lastActionLog($scope=null,$max=5000) {
+        global $app;
+
         $logs = [];
         switch($scope) {
             case 'adminlog':
@@ -143,7 +147,9 @@ final class PrivateAPI
             }
             $log["message"] = $logParser->humanLogMessage($logParser->parse($log["message"]),$log["username"],$log["message"]);
             $log["time"] = date("d.m.Y H:i:s",$log["time"]);
-            $log["username"] = '<a href="/userinfo/'.$log["username"].'" target="_blank">'.$log["username"].'</a>';
+            if ($log["username"] !== "Server Console") {
+                $log["username"] = '<a href="'.$app->getContainer()->router->pathFor('profileId', ['id' => $log['userid']]).'" target="_blank">'.$log["username"].'</a>';
+            }
             $logs[] = $log;
         }
         return $logs;

--- a/src/pxls/Pages/Profile.php
+++ b/src/pxls/Pages/Profile.php
@@ -38,7 +38,16 @@ final class Profile
         $this->data['userdata'] = $user->getUserById($_SESSION['user_id']);
         //endregion
 
-        $userinfo = $this->findUserDetails($this->data["args"]["identifier"]);
+        $method = null; $identifier = null;
+        if (isset($this->data["args"]["username"])) {
+            $method = "name";
+            $identifier = $this->data["args"]["username"];
+        } else if (isset($this->data["args"]["id"])) {
+            $method = "id";
+            $identifier = $this->data["args"]["id"];
+        }
+
+        $userinfo = $this->findUserDetails($method, $identifier);
         if($userinfo) {
             $this->data["userinfo"] = $userinfo;
             krsort($this->data["timeline"]);
@@ -58,9 +67,16 @@ final class Profile
         return $pixels->fetchAll(\PDO::FETCH_OBJ);
     }
 
-    protected function findUserDetails($needle) {
+    protected function findUserDetails($method, $needle) {
         $user = new \pxls\User($this->db); $userinfo = null;
-        $userinfo = $user->getUserByName($needle);
+        switch ($method) {
+            case 'id':
+                $userinfo = $user->getUserById($needle);
+                break;
+            case 'name':
+                $userinfo = $user->getUserByName($needle);
+                break;
+        }
 
         if(!is_null($userinfo) && $userinfo) {
             $userinfo["login_url"] = Utils::MakeUserLoginURL($userinfo["login"]);

--- a/src/pxls/ReportHandler.php
+++ b/src/pxls/ReportHandler.php
@@ -66,8 +66,8 @@ class ReportHandler {
             $report['who_name'] = $report['who'] ? $this->getUserdataById($report['who'])->username : 'Server';
             $report['claimed_name'] = ($report['claimed_by']==0)?'':$this->getUserdataById($report['claimed_by'])->username;
             $report['position_url'] = $report['who'] ? '<a href="'.$this->formatCoordsLink($report['x'], $report['y']).'" target="_blank">X:'.$report['x'].'; Y:'.$report['y'].'</a>' : 'N/A';
-            $report['who_url'] = $report['who'] ? '<a href="/userinfo/'.$report['who_name'].'" target="_blank">'.$report['who_name'].'</a>' : 'Server';
-            $report['reported_url'] = $report['reported'] ? '<a href="/userinfo/'.$report['reported_name'].'" target="_blank">'.$report['reported_name'].'</a>' : 'Server';
+            $report['who_url'] = $report['who'] ? '<a href="'.$app->getContainer()->router->pathFor('profileId', ['id' => $report['who']]).'" target="_blank">'.$report['who_name'].'</a>' : 'Server';
+            $report['reported_url'] = $report['reported'] ? '<a href="'.$app->getContainer()->router->pathFor('profileId', ['id' => $report['reported']]).'" target="_blank">'.$report['reported_name'].'</a>' : 'Server';
             $report['human_time'] = date("d.m.Y - H:i:s",$report['time']);
             if($report['claimed_by'] == 0) {
                 $report['action'] = '<button type="button" class="btn btn-warning btn-xs" data-toggle="modal" data-reportid="'.$report['id'].'" data-target="#report_info">Details</button>';
@@ -159,6 +159,7 @@ class ReportHandler {
             $report['general']['time'] = date("d.m.Y - H:i:s", $gData->time);
 
             $reporterData = $this->getUserdataById($gData->who);
+            $report['reporter']['id']               = $reporterData->id;
             $report['reporter']['username']         = $reporterData->username;
             $report['reporter']['login']            = $reporterData->login;
             $report['reporter']['signup']           = $reporterData->signup_time;
@@ -168,6 +169,7 @@ class ReportHandler {
             $report['reporter']['ban']              = ["expiry"=>$reporterData->ban_expiry,"reason"=>$reporterData->ban_reason];
 
             $reportedData = $this->getUserdataById($gData->reported);
+            $report['reported']['id']               = $reportedData->id;
             $report['reported']['username']         = $reportedData->username;
             $report['reported']['login']            = $reportedData->login;
             $report['reported']['signup']           = $reportedData->signup_time;

--- a/src/routes.php
+++ b/src/routes.php
@@ -10,7 +10,8 @@ $app->get('/reports', \pxls\Action\ReportList::class)->setName('reportList');
 $app->map(['GET', 'POST'], '/chatContext', \pxls\Action\ChatContext::class)->setName('ChatContext');
 
 $app->map(['GET', 'POST'], '/search', \pxls\Action\Search::class)->setName('search');
-$app->map(['GET', 'POST'], '/userinfo/{identifier}', \pxls\Action\Profile::class)->setName('profile');
+$app->map(['GET', 'POST'], '/userinfo/{username}', \pxls\Action\Profile::class)->setName('profileUsername');
+$app->map(['GET', 'POST'], '/userinfo/id/{id}', \pxls\Action\Profile::class)->setName('profileId');
 
 $app->map(['GET','POST'], '/api/private[/{params:.*}]', \pxls\Action\PrivateAPI::class)->setName('prapi');
 $app->get('/api/public[/{params:.*}]', \pxls\Action\PublicAPI::class)->setName('papi');

--- a/src/routes.php
+++ b/src/routes.php
@@ -12,6 +12,10 @@ $app->map(['GET', 'POST'], '/chatContext', \pxls\Action\ChatContext::class)->set
 $app->map(['GET', 'POST'], '/search', \pxls\Action\Search::class)->setName('search');
 $app->map(['GET', 'POST'], '/userinfo/{username}', \pxls\Action\Profile::class)->setName('profileUsername');
 $app->map(['GET', 'POST'], '/userinfo/id/{id}', \pxls\Action\Profile::class)->setName('profileId');
+$app->map(['GET', 'POST'], '/profile/{path:.*}', function(Slim\Http\Request $request, Slim\Http\Response $response, $args) use ($app) {
+	$path = $args["path"];
+	return $response->withRedirect("/userinfo/$path", 307);
+})->setName('profileRedirect');
 
 $app->map(['GET','POST'], '/api/private[/{params:.*}]', \pxls\Action\PrivateAPI::class)->setName('prapi');
 $app->get('/api/public[/{params:.*}]', \pxls\Action\PublicAPI::class)->setName('papi');

--- a/templates/factions.html.twig
+++ b/templates/factions.html.twig
@@ -106,7 +106,7 @@
                 {
                     data: "owner",
                     render: (data, type, row, meta) => {
-                        return `<a href="/userinfo/${data}">${data}</a>`
+                        return `<a href="${'{{path_for('profileId', {'id': '{ID}'})}}'.replace('{ID}', row.id)}">${data}</a>`
                     }
                 },
                 {

--- a/templates/home.html.twig
+++ b/templates/home.html.twig
@@ -378,11 +378,15 @@
                             },
                             {
                                 "data": "initiator_name",
-                                "render": data => `<a href="/userinfo/${data}">${data}</a>`
+                                "render": (data, type, row) => {
+                                    return `<a href="${'{{path_for('profileId', {'id': '{ID}'})}}'.replace('{ID}', row.initiator)}">${data}</a>`;
+                                }
                             },
                             {
                                 "data": "target_name",
-                                "render": data => `<a href="/userinfo/${data}">${data}</a>`
+                                "render": (data, type, row) => {
+                                    return `<a href="${'{{path_for('profileId', {'id': '{ID}'})}}'.replace('{ID}', row.target)}">${data}</a>`;
+                                }
                             },
                             {
                                 "data": "time",

--- a/templates/home/reports.js.twig
+++ b/templates/home/reports.js.twig
@@ -25,7 +25,7 @@ $('#report_info').on('show.bs.modal', function (event) {
             modal.find('#rmd-a-username').closest('.col-md-4').hide();
         } else {
             modal.find('#rmd-a-username').closest('.col-md-4').show();
-            modal.find('#rmd-a-username').html('<a href="/userinfo/' + data.reporter.username + '" target="_blank">' + data.reporter.username + '</a>');
+            modal.find('#rmd-a-username').html(`<a href="${'{{ path_for('profileId', {'id': '{id}'}) }}'.replace('{id}', data.reporter.id)}" target="_blank">${data.reporter.username}</a>`);
             modal.find('#rmd-a-last-ip').html(`<a href="{{ path_for('search') }}?q=${data.reporter.ip.last}&type=ip">${data.reporter.ip.last}</a>`);
             modal.find('#rmd-a-login-ip').html(`<a href="{{ path_for('search') }}?q=${data.reporter.ip.signup}&type=ip">${data.reporter.ip.signup}</a>`);
             modal.find('#rmd-a-login').text(data.reporter.login);
@@ -44,7 +44,7 @@ $('#report_info').on('show.bs.modal', function (event) {
             // This relies on the username existing
             modal.find('#rmd-b-username').closest('.col-md-4').html('<b>Reported data unavailable</b>');
         } else {
-            modal.find('#rmd-b-username').html('<a href="/userinfo/' + data.reported.username + '" target="_blank">' + data.reported.username + '</a>');
+            modal.find('#rmd-b-username').html(`<a href="${'{{ path_for('profileId', {'id': '{id}'}) }}'.replace('{id}', data.reported.id)}" target="_blank">${data.reported.username}</a>`);
             modal.find('#rmd-b-login').text(data.reported.login);
             modal.find('#rmd-b-last-ip').html(`<a href="{{ path_for('search') }}?q=${data.reported.ip.last}&type=ip">${data.reported.ip.last}</a>`);
             modal.find('#rmd-b-login-ip').html(`<a href="{{ path_for('search') }}?q=${data.reported.ip.signup}&type=ip">${data.reported.ip.signup}</a>`);
@@ -120,8 +120,8 @@ $('#chat_report_modal').on('show.bs.modal', function (event) {
         modal.find('#rmd-g-id').text(data.report.details.id);
 
         //details
-        modal.find('#crm-details-reporter').html($('<a>').attr('href', `/userinfo/${data.reporter.username}`).text(data.reporter.username));
-        modal.find('#crm-details-reported').html($('<a>').attr('href', `/userinfo/${data.reported.username}`).text(data.reported.username));
+        modal.find('#crm-details-reporter').html($('<a>').attr('href', '{{ path_for('profileId', {'id': '{id}'}) }}'.replace('{id}', data.reporter.id)).text(data.reporter.username));
+        modal.find('#crm-details-reported').html($('<a>').attr('href', '{{ path_for('profileId', {'id': '{id}'}) }}'.replace('{id}', data.reported.id)).text(data.reported.username));
         modal.find('#crm-details-sent').text(moment.unix(data.report.details.time).format('MM.DD.YYYY HH:mm:ss'));
         modal.find('#crm-details-reason').text(data.report.details.report_message);
         modal.find('#crm-details-chat-line').text(data.report.message.content);

--- a/templates/search.html.twig
+++ b/templates/search.html.twig
@@ -39,7 +39,7 @@
                                 <tr>
                                     <td>{{ user.id }}</td>
                                     <td>
-                                        <a href="{{ base_url() }}{{ path_for('profile', {'identifier': user.username}) }}">
+                                        <a href="{{ base_url() }}{{ path_for('profileId', {'id': user.id}) }}">
                                             {{ user.username }}
                                         </a>
                                     </td>

--- a/templates/userinfo.html.twig
+++ b/templates/userinfo.html.twig
@@ -148,7 +148,7 @@
                                     <i class="fa fa-user-times bg-red"></i>
                                     <div class="timeline-item">
                                         <span class="time"></span>
-                                        <h3 class="timeline-header"><a href="{{ path_for('profile', {'identifier': userinfo.username}) }}">{{ userinfo.username }}</a> is banned until {{ userinfo.ban_expiry|date("d.m.Y H:i:s") }}</h3>
+                                        <h3 class="timeline-header"><a href="{{ path_for('profileId', {'id': userinfo.id}) }}">{{ userinfo.username }}</a> is banned until {{ userinfo.ban_expiry|date("d.m.Y H:i:s") }}</h3>
                                         <div class="timeline-body">
                                             {{ userinfo.ban_reason }}
                                         </div>
@@ -161,7 +161,7 @@
                                     <i class="fa fa-user-times bg-red"></i>
                                     <div class="timeline-item">
                                         <span class="time"></span>
-                                        <h3 class="timeline-header"><a href="{{ path_for('profile', {'identifier': userinfo.username}) }}">{{ userinfo.username }}</a> was  {% if userinfo.is_shadow_banned %}shadow-{% endif %}banned{% if not userinfo.is_shadow_banned and userinfo.is_ban_permanent %} permanently{% endif %}</h3>
+                                        <h3 class="timeline-header"><a href="{{ path_for('profileId', {'id': userinfo.id}) }}">{{ userinfo.username }}</a> was  {% if userinfo.is_shadow_banned %}shadow-{% endif %}banned{% if not userinfo.is_shadow_banned and userinfo.is_ban_permanent %} permanently{% endif %}</h3>
                                         <div class="timeline-body">
                                             {{ userinfo.ban_reason }}
                                         </div>
@@ -181,11 +181,11 @@
                                     <div class="timeline-item">
                                         <span class="time"><i class="fa fa-clock-o"></i> {{ key|date() }}</span>
                                         {% if item.scope == "report_sent" %}
-                                            <h3 class="timeline-header no-border"><a href="{{ path_for('profile', {'identifier': userinfo.username}) }}">{{ userinfo.username }}</a> reported <a href="{{ path_for('profile',{'identifier': item.id.reported.username }) }}">{{ item.id.reported.username }}</a>. (Report ID: <a href="#" data-toggle="modal" data-reportid="{{ item.id.id }}" data-target="#report_info">{{ item.id.id }}</a>)</h3>
+                                            <h3 class="timeline-header no-border"><a href="{{ path_for('profileId', {'id': userinfo.id}) }}">{{ userinfo.username }}</a> reported <a href="{{ path_for('profileId',{'id': item.id.reported.id }) }}">{{ item.id.reported.username }}</a>. (Report ID: <a href="#" data-toggle="modal" data-reportid="{{ item.id.id }}" data-target="#report_info">{{ item.id.id }}</a>)</h3>
                                         {% elseif item.scope == "report_recv" %}
-                                            <h3 class="timeline-header no-border"><a href="{{ path_for('profile', {'identifier': userinfo.username}) }}">{{ userinfo.username }}</a> was reported by <a href="{{ path_for('profile',{'identifier': item.id.reporter.username }) }}">{{ item.id.reporter.username }}</a>. (Report ID: <a href="#" data-toggle="modal" data-reportid="{{ item.id.id }}" data-target="#report_info">{{ item.id.id }}</a>)</h3>
+                                            <h3 class="timeline-header no-border"><a href="{{ path_for('profileId', {'id': userinfo.id}) }}">{{ userinfo.username }}</a> was reported by <a href="{{ path_for('profileId',{'id': item.id.reporter.id }) }}">{{ item.id.reporter.username }}</a>. (Report ID: <a href="#" data-toggle="modal" data-reportid="{{ item.id.id }}" data-target="#report_info">{{ item.id.id }}</a>)</h3>
                                         {% elseif item.scope == "signup" %}
-                                            <h3 class="timeline-header no-border"><a href="{{ path_for('profile', {'identifier': userinfo.username}) }}">{{ userinfo.username }}</a> signed up.</h3>
+                                            <h3 class="timeline-header no-border"><a href="{{ path_for('profileId', {'id': userinfo.id}) }}">{{ userinfo.username }}</a> signed up.</h3>
                                         {% endif %}
 
                                         {% if item.entry != "" %}
@@ -331,7 +331,7 @@
                                 <div class="user-block">
                                     <img class="img-circle img-bordered-sm" src="{{ base_url() }}/assets/img/image-78.png" alt="user image">
                                     <span class="username">
-                                        <a href="{{ path_for('profile', {'identifier': note.user_name}) }}">{{ note.user_name }}</a>
+                                        <a href="{{ path_for('profileId', {'id': note.user_id}) }}">{{ note.user_name }}</a>
                                         <a href="#" class="pull-right btn-box-tool deletenote" data-targetid="{{ note.id }}"><i class="fa fa-times"></i></a>
                                     </span>
                                     <span class="description">{{ note.timestamp|date("d.m.Y - H:i:s") }}</span>

--- a/templates/userinfo.html.twig
+++ b/templates/userinfo.html.twig
@@ -242,7 +242,7 @@
                                             <div class="timeline-item">
                                                 <span class="time"><i class="fa fa-clock-o"></i> {{ item.when|date() }}</span>
                                                 <div class="timeline-body">
-                                                    <a href="{{ base_url() }}/userinfo/{{ item.banner }}" target="_blank">{{ item.banner }}</a> <span>{{ item.action }}ned</span> <span>{{ item.banned }}</span> {% if item.length > 0 %}for <span>{{ item.length }}</span> seconds{% endif %}
+                                                    <a href="{{ path_for('profileId', {'id': item.banner_id}) }}" target="_blank">{{ item.banner }}</a> <span>{{ item.action }}ned</span> <a href="{{ path_for('profileId', {'id': item.banned_id}) }}" target="_blank">{{ item.banned }}</a> {% if item.length > 0 %}for <span>{{ item.length }}</span> seconds{% endif %}
                                                     {% if item.ban_reason|length > 0 %}
                                                         <p><strong>Reason:</strong> <span>{{ item.ban_reason }}</span></p>
                                                     {% endif %}
@@ -305,7 +305,7 @@
                                             <div class="timeline-item">
                                                 <span class="time"><i class="fa fa-clock-o"></i> {{ item.when|date() }}</span>
                                                 <div class="timeline-body">
-                                                    <a href="{{ base_url() }}/userinfo/{{ item.banner }}" target="_blank">{{ item.banner }}</a> <span>{{ item.type == 'UNBAN' ? 'un' : '' }}banned</span> <span>{{ item.banned }}</span> {% if item.length > 0 %} for <span>{{ item.length }}</span> seconds{% endif %}
+                                                    <a href="{{ path_for('profileId', {'id': item.banner_id}) }}" target="_blank">{{ item.banner }}</a> <span>{{ item.type == 'UNBAN' ? 'un' : '' }}banned</span> <a href="{{ path_for('profileId', {'id': item.banned_id}) }}" target="_blank">{{ item.banned }}</a> {% if item.length > 0 %} for <span>{{ item.length }}</span> seconds{% endif %}
                                                     {% if item.ban_reason|length > 0 %}
                                                         <p><strong>Reason:</strong> <span>{{ item.ban_reason }}</span></p>
                                                     {% endif %}
@@ -483,7 +483,7 @@
                 });
                 $.post("{{ webroots.game }}/admin/forceNameChange", {user: this.dataset.username, newName}, function() {
                     alert('Success');
-                    document.location.href = `{{ webroots.panel }}/userinfo/${newName}`;
+                    document.location.href = `{{ webroots.panel }}${'{{ path_for('profileUsername', {'username': '{username}'}) }}'.replace('{username}', newName)}`;
                 }).fail(function() {
                     alert('An error occurred');
                 });


### PR DESCRIPTION
Due to the addition of name changes, `/userinfo/{username}` could sometimes be invalid paths. This PR adds `/userinfo/id/{id}`, which fetches an user's profile using their ID instead of just their username.

This also replaces most instances of `/userinfo/{username}` with `/userinfo/id/{id}` whenever possible, with the exceptions being:
- When a force rename is executed, the page will still redirect to `/userinfo/{newName}`
- Logs on the Last Actions section of the home page will still use the hardcoded `/userinfo/{username}` until #17 is merged.

The PR also adds a redirect from `/profile/{...}` to `/userinfo/{...}`, so that staff can simply add "admin." at the beginning of the domain to go from the in-game profile to the admin page profile.