### PR TITLE
Configurable server time and renderer debug mode.

### DIFF
--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -10,10 +10,11 @@ $container['renderer'] = function ($c) {
     $settings = $c->get('settings')['renderer'];
     $view = new Slim\Views\Twig($settings['template_path'], [
         'cache' => $settings['cache_path'],
-        'debug' => true,
+        'debug' => $settings['debug'],
     ]);
     $basePath = rtrim(str_ireplace('index.php', '', $c['request']->getUri()->getBasePath()), '/');
     $view->addExtension(new Slim\Views\TwigExtension($c['router'], $basePath));
+    if ($settings['debug']) {
     $view->addExtension(new Twig_Extension_Debug());
     return $view;
 };

--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -14,8 +14,10 @@ $container['renderer'] = function ($c) {
     ]);
     $basePath = rtrim(str_ireplace('index.php', '', $c['request']->getUri()->getBasePath()), '/');
     $view->addExtension(new Slim\Views\TwigExtension($c['router'], $basePath));
+    $view->getEnvironment()->addGlobal('server_timezone_name', date_default_timezone_get());
     if ($settings['debug']) {
-    $view->addExtension(new Twig_Extension_Debug());
+        $view->addExtension(new Twig_Extension_Debug());
+    }
     return $view;
 };
 

--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -15,6 +15,7 @@ $container['renderer'] = function ($c) {
     $basePath = rtrim(str_ireplace('index.php', '', $c['request']->getUri()->getBasePath()), '/');
     $view->addExtension(new Slim\Views\TwigExtension($c['router'], $basePath));
     $view->getEnvironment()->addGlobal('server_timezone_name', date_default_timezone_get());
+    $view->getEnvironment()->addGlobal('webroots', $c->get("settings")["webroots"]);
     if ($settings['debug']) {
         $view->addExtension(new Twig_Extension_Debug());
     }

--- a/src/pxls/Pages/Factions.php
+++ b/src/pxls/Pages/Factions.php
@@ -35,7 +35,7 @@ final class Factions
                 $response = $response->withStatus(200)->withJson(['status' => 'success', 'data' => $factions]);
                 break;
             case 'text/html':
-                $this->view->render($response, 'factions.html.twig', ['args' => $args, 'userdata' => (new \pxls\User($this->database))->getUserById($_SESSION['user_id']), 'webroots' => $app->getContainer()->get("settings")["webroots"]]);
+                $this->view->render($response, 'factions.html.twig', ['args' => $args, 'userdata' => (new \pxls\User($this->database))->getUserById($_SESSION['user_id'])]);
                 break;
         }
 

--- a/src/pxls/Pages/Home.php
+++ b/src/pxls/Pages/Home.php
@@ -28,7 +28,6 @@ final class Home
 
         $data = [];
         $data['args'] = $args;
-        $data['webroots'] = $app->getContainer()->get("settings")["webroots"];
 
         //region UserData
         $user = new \pxls\User($this->database);

--- a/src/pxls/Pages/LogPage.php
+++ b/src/pxls/Pages/LogPage.php
@@ -28,7 +28,6 @@ final class LogPage
         global $app;
         $data = [];
         $data['args'] = $args;
-        $data['webroots'] = $app->getContainer()->get("settings")["webroots"];
 
         //region UserData
         $user = new \pxls\User($this->database);

--- a/src/pxls/Pages/NotifyController.php
+++ b/src/pxls/Pages/NotifyController.php
@@ -30,7 +30,6 @@ final class NotifyController
 
         //region Meta
         $data['args'] = $args;
-        $data['webroots'] = $app->getContainer()->get("settings")["webroots"];
         //endregion
 
         //region UserData

--- a/src/pxls/Pages/Profile.php
+++ b/src/pxls/Pages/Profile.php
@@ -25,8 +25,6 @@ final class Profile
         $this->db = $database;
         $this->discord = $discord;
         $this->discord->setName($settings["discord"]["name"]." - UserInfo");
-
-        $this->data['webroots'] = $settings["webroots"];
     }
 
     public function __invoke(Request $request, Response $response, $args)

--- a/src/pxls/Pages/Search.php
+++ b/src/pxls/Pages/Search.php
@@ -27,7 +27,6 @@ final class Search
     public function __invoke(Request $request, Response $response, $args)
     {
         global $app;
-        $data['webroots'] = $app->getContainer()->get("settings")["webroots"];
         $user = new \pxls\User($this->database);
         $data['userdata'] = $user->getUserById($_SESSION['user_id']);
         if(empty($request->getParam('q'))) {

--- a/src/settings.example.php
+++ b/src/settings.example.php
@@ -7,13 +7,14 @@ return [
         // Renderer settings
         'renderer' => [
             'template_path' => __DIR__ . '/../templates/',
-            'cache_path'    => __DIR__ . '/../cache/'
+            'cache_path'    => __DIR__ . '/../cache/',
+            'debug'         => false
         ],
 
         // Monolog settings
         'logger' => [
-            'name' => 'pxlsAdmin',
-            'path' => __DIR__ . '/../logs/app.log', // comment this out to only log to the database
+            'name'  => 'pxlsAdmin',
+            'path'  => __DIR__ . '/../logs/app.log', // comment this out to only log to the database
             'level' => \Monolog\Logger::DEBUG
         ],
 

--- a/templates/master.html.twig
+++ b/templates/master.html.twig
@@ -49,8 +49,8 @@
                 <ul class="nav navbar-nav">
                     <!-- User Account: style can be found in dropdown.less -->
                     <li class="messages-menu">
-                        <a href="#"><b>CEST Time:</b>
-                            <span id="cest-time"></span>
+                        <a href="#"><b>{{ server_timezone_name }} Time:</b>
+                            <span id="server-time"></span>
                         </a>
                     </li>
                     <li class="dropdown user user-menu">
@@ -185,7 +185,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.18.1/moment-with-locales.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.13/moment-timezone-with-data.min.js"></script>
     <script type="text/javascript">
-        setInterval(function(){$("#cest-time").html(moment().tz('Europe/Berlin').format('YYYY-MM-DD HH:mm:ss'))}, 1000);
+        setInterval(function(){$("#server-time").html(moment().tz('{{ server_timezone_name }}').format('YYYY-MM-DD HH:mm:ss'))}, 1000);
     </script>
 {% endblock %}
 


### PR DESCRIPTION
This PR:
- Adds a setting to toggle debug mode on the Twig renderer
- Makes the server send its timezone to the client, instead of using the hardcoded CEST or "Europe/Berlin"
- Moves 'webroots' to be a global variable for the renderer.

I decided to merge these three changes into a single PR to save time.

### Configuration change
Must set `renderer.debug`.
```diff
          'renderer' => [
              'template_path' => __DIR__ . '/../templates/',
              'cache_path'    => __DIR__ . '/../cache/',
+             'debug'         => true // or false
          ],
```
Twig's debug mode was enabled by default. To enable it again simply set that to true on your settings.php